### PR TITLE
#209 - Use Transactional row locks for job timeouts /  Instant re-queue for background jobs even on ungraceful shutdown

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -139,6 +139,7 @@ namespace Hangfire.PostgreSql
       logger.InfoFormat("    Queue poll interval: {0}.", Options.QueuePollInterval);
       logger.InfoFormat("    Invisibility timeout: {0}.", Options.InvisibilityTimeout);
       logger.InfoFormat("    Sliding invisibility timeout: {0}.", Options.SlidingInvisibilityTimeout.HasValue ? Options.SlidingInvisibilityTimeout : "disabled");
+      logger.InfoFormat("    Transaction job timeout: {0}.", Options.UseTransactionalJobTimeout);
     }
 
     public override string ToString()
@@ -326,7 +327,7 @@ namespace Hangfire.PostgreSql
       }
     }
 
-    internal void ReleaseConnection(DbConnection connection)
+    internal void ReleaseConnection(IDbConnection connection)
     {
       if (connection != null && !IsExistingConnection(connection))
       {
@@ -334,7 +335,7 @@ namespace Hangfire.PostgreSql
       }
     }
 
-    private bool IsExistingConnection(IDbConnection connection)
+    internal bool IsExistingConnection(IDbConnection connection)
     {
       return connection != null && _connectionFactory is ExistingNpgsqlConnectionFactory && ReferenceEquals(connection, _connectionFactory.GetOrCreateConnection());
     }

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -51,6 +51,7 @@ namespace Hangfire.PostgreSql
       PrepareSchemaIfNecessary = true;
       EnableTransactionScopeEnlistment = true;
       DeleteExpiredBatchSize = 1000;
+      UseTransactionalJobTimeout = false;
     }
 
     public TimeSpan QueuePollInterval
@@ -146,6 +147,7 @@ namespace Hangfire.PostgreSql
     public string SchemaName { get; set; }
     public bool EnableTransactionScopeEnlistment { get; set; }
     public bool EnableLongPolling { get; set; }
+    public bool UseTransactionalJobTimeout { get; set; }
 
     private static void ThrowIfValueIsNotPositive(TimeSpan value, string fieldName)
     {

--- a/src/Hangfire.PostgreSql/PostgreSqlTransactionJob.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlTransactionJob.cs
@@ -1,0 +1,127 @@
+﻿// This file is part of Hangfire.PostgreSql.
+// Copyright © 2014 Frank Hommers <http://hmm.rs/Hangfire.PostgreSql>.
+// 
+// Hangfire.PostgreSql is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire.PostgreSql  is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire.PostgreSql. If not, see <http://www.gnu.org/licenses/>.
+//
+// This work is based on the work of Sergey Odinokov, author of 
+// Hangfire. <http://hangfire.io/>
+//   
+//    Special thanks goes to him.
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using Dapper;
+using Hangfire.Logging;
+using Hangfire.PostgreSql.Utils;
+using Hangfire.Storage;
+
+namespace Hangfire.PostgreSql
+{
+  public class PostgreSqlTransactionJob : IFetchedJob
+  {
+    // We have a keep alive to ensure that proxies or pg_bouncer don't close this as
+    // an idle connection
+    private static readonly TimeSpan _keepAliveInterval = TimeSpan.FromMinutes(1);
+    private readonly object _lockObject = new();
+
+    private readonly ILog _logger = LogProvider.GetLogger(typeof(PostgreSqlTransactionJob));
+
+    private readonly PostgreSqlStorage _storage;
+
+    private readonly Timer _timer;
+    private readonly IDbTransaction _transaction;
+    private IDbConnection _connection;
+    private bool _disposed;
+
+    public PostgreSqlTransactionJob(
+      PostgreSqlStorage storage,
+      IDbConnection connection,
+      IDbTransaction transaction,
+      string jobId,
+      string queue)
+    {
+      _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+      _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+      _transaction = transaction ?? throw new ArgumentNullException(nameof(transaction));
+
+      JobId = jobId ?? throw new ArgumentNullException(nameof(jobId));
+      Queue = queue ?? throw new ArgumentNullException(nameof(queue));
+
+      if (!_storage.IsExistingConnection(_connection))
+      {
+        _timer = new Timer(ExecuteKeepAliveQuery, null, _keepAliveInterval, _keepAliveInterval);
+      }
+    }
+
+    public string Queue { get; }
+    public string JobId { get; }
+
+    public void RemoveFromQueue()
+    {
+      lock (_lockObject)
+      {
+        _transaction.Commit();
+      }
+    }
+
+    public void Requeue()
+    {
+      lock (_lockObject)
+      {
+        _transaction.Rollback();
+      }
+    }
+
+    public void Dispose()
+    {
+      if (_disposed)
+      {
+        return;
+      }
+
+      _disposed = true;
+
+      // Timer callback may be invoked after the Dispose method call,
+      // so we are using lock to avoid unsynchronized calls.
+      lock (_lockObject)
+      {
+        _timer?.Dispose();
+        _transaction.Dispose();
+        _storage.ReleaseConnection(_connection);
+        _connection = null;
+      }
+    }
+
+    private void ExecuteKeepAliveQuery(object obj)
+    {
+      lock (_lockObject)
+      {
+        try
+        {
+          _connection?.Execute("SELECT 1;", transaction: _transaction);
+        }
+        catch (Exception ex) when (ex.IsCatchableExceptionType())
+        {
+          // Connection was closed. So we can't continue to send
+          // keep-alive queries. Unlike for distributed locks,
+          // there is no any caveats of having this issue for
+          // queues, because Hangfire guarantees only the "at least
+          // once" processing.
+        }
+      }
+    }
+  }
+}

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlTransactionJobFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlTransactionJobFacts.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Data;
+using Hangfire.PostgreSql.Tests.Utils;
+using Moq;
+using Xunit;
+
+// ReSharper disable AssignNullToNotNullAttribute
+
+namespace Hangfire.PostgreSql.Tests
+{
+  public class PostgreSqlTransactionJobFacts
+  {
+    private const string JobId = "id";
+    private const string Queue = "queue";
+
+    private readonly Mock<IDbConnection> _connection;
+    private readonly Mock<IDbTransaction> _transaction;
+    private readonly PostgreSqlStorage _storage;
+
+    public PostgreSqlTransactionJobFacts()
+    {
+      _connection = new Mock<IDbConnection>();
+      _transaction = new Mock<IDbTransaction>();
+      _storage = new PostgreSqlStorage(ConnectionUtils.GetDefaultConnectionFactory());
+    }
+
+    [Fact]
+    public void Ctor_ThrowsAnException_WhenStorageIsNull()
+    {
+      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+        () => new PostgreSqlTransactionJob(null, _connection.Object, _transaction.Object, JobId, Queue));
+
+      Assert.Equal("storage", exception.ParamName);
+    }
+
+    [Fact]
+    public void Ctor_ThrowsAnException_WhenConnectionIsNull()
+    {
+      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+        () => new PostgreSqlTransactionJob(_storage, null, _transaction.Object, JobId, Queue));
+
+      Assert.Equal("connection", exception.ParamName);
+    }
+
+    [Fact]
+    public void Ctor_ThrowsAnException_WhenTransactionIsNull()
+    {
+      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+        () => new PostgreSqlTransactionJob(_storage, _connection.Object, null, JobId, Queue));
+
+      Assert.Equal("transaction", exception.ParamName);
+    }
+
+    [Fact]
+    public void Ctor_ThrowsAnException_WhenJobIdIsNull()
+    {
+      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+        () => new PostgreSqlTransactionJob(_storage, _connection.Object, _transaction.Object, null, Queue));
+
+      Assert.Equal("jobId", exception.ParamName);
+    }
+
+    [Fact]
+    public void Ctor_ThrowsAnException_WhenQueueIsNull()
+    {
+      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+        () => new PostgreSqlTransactionJob(_storage, _connection.Object, _transaction.Object, JobId, null));
+
+      Assert.Equal("queue", exception.ParamName);
+    }
+
+    [Fact]
+    public void Ctor_CorrectlySets_AllInstanceProperties()
+    {
+      PostgreSqlTransactionJob fetchedJob = new PostgreSqlTransactionJob(_storage, _connection.Object, _transaction.Object, JobId, Queue);
+
+      Assert.Equal(JobId, fetchedJob.JobId);
+      Assert.Equal(Queue, fetchedJob.Queue);
+    }
+
+    [Fact]
+    [CleanDatabase]
+    public void RemoveFromQueue_CommitsTheTransaction()
+    {
+      // Arrange
+      PostgreSqlTransactionJob processingJob = CreateFetchedJob("1", "default");
+
+      // Act
+      processingJob.RemoveFromQueue();
+
+      // Assert
+      _transaction.Verify(x => x.Commit());
+    }
+
+    [Fact]
+    [CleanDatabase]
+    public void Requeue_RollsbackTheTransaction()
+    {
+      // Arrange
+      PostgreSqlTransactionJob processingJob = CreateFetchedJob("1", "default");
+
+      // Act
+      processingJob.Requeue();
+
+      // Assert
+      _transaction.Verify(x => x.Rollback());
+    }
+
+    [Fact]
+    [CleanDatabase]
+    public void Dispose_DisposesTheTransactionAndConnection()
+    {
+      PostgreSqlTransactionJob processingJob = CreateFetchedJob("1", "queue");
+
+      // Act
+      processingJob.Dispose();
+
+      // Assert
+      _transaction.Verify(x => x.Dispose());
+      _connection.Verify(x => x.Dispose());
+    }
+
+    private PostgreSqlTransactionJob CreateFetchedJob(string jobId, string queue)
+    {
+      return new PostgreSqlTransactionJob(_storage, _connection.Object, _transaction.Object, jobId, queue);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for Instant re-queue for background jobs even on ungraceful shutdown (as discussed in https://github.com/hangfire-postgres/Hangfire.PostgreSql/issues/209) which is ported from SQL Server storage.

This is implemented by executing a query to delete the top waiting job inside a transaction (with the row locked) but not committing that transaction until the job is completed.  This ensures that if the server fails and connection drops, the transaction is rolled back and the job can be picked up straight away by another worker.

The advantage is do not need to wait for a long timeout (like sliding invisibility /invisibility timeouts) for a job to be requeued but the disadvantage is that this holds a transaction open for the lifetime of the job.  

The disadvantage is holding open transactions for long periods can cause issues with vacuum ([see this message](https://www.postgresql.org/message-id/44355FEA.1060702@positivenetworks.net) and [this Stackoverflow post](https://stackoverflow.com/questions/33815267/what-are-the-consequences-of-not-ending-a-database-transaction/33815610#33815610)) and potentially with replication.

This is why both sliding invisibility and transaction row locking are available (similar to SQL Server storage) to support cases where very long running jobs may be required and need to avoid causing problems with backups/replication/vacuum etc.